### PR TITLE
Optimize for player screen

### DIFF
--- a/Specs/ZeeHomeScreen/2.2.9/ZeeHomeScreen.podspec
+++ b/Specs/ZeeHomeScreen/2.2.9/ZeeHomeScreen.podspec
@@ -1,0 +1,34 @@
+Pod::Spec.new do |s|
+  s.name             = "ZeeHomeScreen"
+  s.version          = '2.2.9'
+  s.summary          = "ZeeHomeScreen"
+  s.description      = <<-DESC
+                      Zee Home Screen
+                       DESC
+  s.homepage         = 'https://github.com/applicaster-plugins/ZeeHomeScreen-iOS'
+  s.license          = 'CMPS'
+  s.author           = { "cmps" => "m.vecselboim@applicaster.com" }
+  s.source           = { :git => 'git@github.com:applicaster-plugins/ZeeHomeScreen-iOS.git', :tag => s.version.to_s }
+  s.platform     = :ios, '10.0'
+  s.requires_arc = true
+
+  s.public_header_files = 'ZeeHomeScreen/**/*.h'
+  s.source_files = 'ZeeHomeScreen/**/*.{h,m,swift}'
+
+  s.resources = [
+    "ZeeHomeScreen/**/*.{png,xib}",
+    'ZeeHomeScreen/**/*.plist'
+  ]
+
+  s.xcconfig =  { 'CLANG_ALLOW_NON_MODULAR_INCLUDES_IN_FRAMEWORK_MODULES' => 'YES',
+                  'ENABLE_BITCODE' => 'YES',
+                  'SWIFT_VERSION' => '5.1'
+                }
+
+  s.dependency 'ZappPlugins'
+  s.dependency 'ApplicasterSDK'
+  s.dependency 'ApplicasterUIKit'
+  s.dependency 'ZappSDK'
+  s.dependency 'Zee5CoreSDK'
+
+end

--- a/ZeeHomeScreen.podspec
+++ b/ZeeHomeScreen.podspec
@@ -29,5 +29,6 @@ Pod::Spec.new do |s|
   s.dependency 'ApplicasterSDK'
   s.dependency 'ApplicasterUIKit'
   s.dependency 'ZappSDK'
+  s.dependency 'Zee5CoreSDK'
 
 end

--- a/ZeeHomeScreen/Classes/Components/SectionComposite/SectionCompositeFlowLayout.swift
+++ b/ZeeHomeScreen/Classes/Components/SectionComposite/SectionCompositeFlowLayout.swift
@@ -699,6 +699,22 @@ import ApplicasterSDK
     @objc public func isVertical() -> Bool {
         return scrollDirection == .vertical
     }
+    
+    
+    //    /**
+    //     For a given index path, retrieve the cached cell size, if it exists, otherwise get the estimated size from the
+    //     cell's component attributes.
+    //
+    //     - parameters indexPath: The index path of the cell whose size is being calculated.
+    //     - parameters сollectionItemTypes: Items type of the section group
+    //
+    //     - returns: The size to be used for the cell.
+    //     */
+    func cellSize(for indexPath: IndexPath,
+                  сollectionItemTypes: ComponentHelper.ComponentItemTypes) -> CGSize? {
+        //        return CGSize.init(width: 150.0, height: 150.0)
+        return  /*cachedIndexPathSizes[indexPath] ??*/ estimatedCellSize(for: indexPath, сollectionItemTypes: сollectionItemTypes)
+    }
 }
 
 extension SectionCompositeFlowLayout {
@@ -784,21 +800,6 @@ extension SectionCompositeFlowLayout {
         }
         
         return CGSize.zero //init(width: UIScreen.main.bounds.width, height: UIScreen.main.bounds.width / 4)
-    }
-
-    //    /**
-    //     For a given index path, retrieve the cached cell size, if it exists, otherwise get the estimated size from the
-    //     cell's component attributes.
-    //
-    //     - parameters indexPath: The index path of the cell whose size is being calculated.
-    //     - parameters сollectionItemTypes: Items type of the section group
-    //
-    //     - returns: The size to be used for the cell.
-    //     */
-    func cellSize(for indexPath: IndexPath,
-                  сollectionItemTypes: ComponentHelper.ComponentItemTypes) -> CGSize? {
-        //        return CGSize.init(width: 150.0, height: 150.0)
-        return  /*cachedIndexPathSizes[indexPath] ??*/ estimatedCellSize(for: indexPath, сollectionItemTypes: сollectionItemTypes)
     }
     
     //    /**

--- a/ZeeHomeScreen/Classes/Components/SectionComposite/StaticViewCollectionViewController.swift
+++ b/ZeeHomeScreen/Classes/Components/SectionComposite/StaticViewCollectionViewController.swift
@@ -1,0 +1,184 @@
+//
+//  StaticViewCollectionViewController.swift
+//  ZeeHomeScreen
+//
+//  Created by Simon Borkin on 14.05.20.
+//
+
+import Foundation
+
+import ApplicasterSDK
+import ZappPlugins
+
+fileprivate let defaultCellIdentifier = "default"
+
+public class StaticViewCollectionViewController: UIViewController {
+    fileprivate var sectionCompositeViewController: StaticViewSectionCompositeViewController?
+    
+    public func load(_ atomFeed: APAtomFeed, staticView: UIView) {
+        guard let sectionCompositeViewController = StaticViewSectionCompositeViewController.create(for: atomFeed, staticView) else {
+            return
+        }
+        
+        self.sectionCompositeViewController = sectionCompositeViewController
+        
+        self.addChild(sectionCompositeViewController)
+        self.view.addSubview(sectionCompositeViewController.view)
+
+        sectionCompositeViewController.view.fillParent()
+        
+        sectionCompositeViewController.didMove(toParent: self)
+        
+        self.updateStaticView(staticView)
+    }
+    
+    public func invalidateLayout() {
+        guard
+            let collectionView = self.sectionCompositeViewController?.collectionView,
+            let flowLayout = collectionView.collectionViewLayout as? StaticViewFlowLayout else {
+            return
+        }
+        
+        flowLayout.prepare(forceUpdate: true)
+        flowLayout.invalidateLayout()
+    }
+    
+    fileprivate func updateStaticView(_ staticView: UIView) {
+        guard
+            let sectionCompositeViewController = self.sectionCompositeViewController,
+            let collectionView = sectionCompositeViewController.collectionView,
+            let flowLayout = collectionView.collectionViewLayout as? StaticViewFlowLayout else {
+            return
+        }
+
+        collectionView.register(UICollectionViewCell.self, forCellWithReuseIdentifier: defaultCellIdentifier)
+        
+        if sectionCompositeViewController.sectionsDataSourceArray == nil {
+            sectionCompositeViewController.sectionsDataSourceArray = []
+        }
+        
+        sectionCompositeViewController.sectionsDataSourceArray?.insert(ComponentModel(type: defaultCellIdentifier), at: 0)
+        flowLayout.staticView = staticView
+        
+        collectionView.reloadData()
+    }
+}
+
+fileprivate class StaticViewSectionCompositeViewController: SectionCompositeViewController {
+    public var staticView: UIView!
+    
+    public static func create(for atomFeed: APAtomFeed?, _ staticView: UIView) -> StaticViewSectionCompositeViewController? {
+        let result = StaticViewSectionCompositeViewController()
+        result.staticView = staticView
+        
+        var config: PluginKeys?
+        var style: PluginKeys?
+        
+        if let screenModel = ZAAppConnector.sharedInstance().genericDelegate.screenModelForPluginID(pluginID: "zee5_home_screen", dataSource: nil) {
+            config = screenModel.general as? PluginKeys ?? PluginKeys()
+            style = screenModel.style?.object as? PluginKeys ?? PluginKeys()
+        }
+        
+        var pluginConfiguration: NSDictionary?
+        
+        if let pluginModel = ZPPluginManager.pluginModelById("zee5_home_screen") {
+            pluginConfiguration = pluginModel.configurationJSON
+        }
+        
+        let collectionView = UICollectionView(frame: CGRect.zero, collectionViewLayout: UICollectionViewFlowLayout())
+        result.collectionView = collectionView
+        result.view.addSubview(collectionView)
+        collectionView.fillParent()
+
+        result.screenConfiguration = ScreenConfiguration.init(config: config, style: style, dataSource: atomFeed, configurationJSON: pluginConfiguration)
+        result.setComponentModel((Zee5dsAdapter.getBaseComponent(for: atomFeed))!)
+        result.atomFeedUrl = atomFeed?.link
+        result.modalPresentationStyle = .fullScreen
+
+        collectionView.delegate = result
+        collectionView.dataSource = result
+        
+        return result
+    }
+        
+    override func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        var result: UICollectionViewCell!
+                
+        if let componentModel = self.sectionsDataSourceArray?.componentModel(at: indexPath), componentModel.type == defaultCellIdentifier {
+            result = collectionView.dequeueReusableCell(withReuseIdentifier: defaultCellIdentifier, for: indexPath)
+            
+            if let view = self.staticView {
+                result.contentView.addSubview(view)
+                view.fillParent()
+            }
+            
+        }
+        
+        if result == nil {
+            result = super.collectionView(collectionView, cellForItemAt: indexPath)
+        }
+        
+        return result
+    }
+    
+    override func collectionFlowLayout() -> UICollectionViewFlowLayout {
+        let result = StaticViewFlowLayout()
+        result.staticView = self.staticView
+        
+        return result
+    }
+}
+
+
+
+fileprivate class StaticViewFlowLayout: SectionCompositeFlowLayout {
+    var staticView: UIView?
+    
+    override func cellSize(for indexPath: IndexPath, сollectionItemTypes: ComponentHelper.ComponentItemTypes) -> CGSize? {
+        if  let staticView = self.staticView,
+            let componentModel = self.sectionsDataSourceArray?.componentModel(at: indexPath),
+            componentModel.type == defaultCellIdentifier,
+            let collectionView = self.collectionView  {
+
+            let fullWidth = collectionView.bounds.width
+            let targetSize = CGSize(width: fullWidth, height: UIView.layoutFittingCompressedSize.width)
+            
+            let result = staticView.systemLayoutSizeFitting(targetSize, withHorizontalFittingPriority: UILayoutPriority.required, verticalFittingPriority: UILayoutPriority.defaultLow)
+            
+            return result
+        }
+        
+        return super.cellSize(for: indexPath, сollectionItemTypes: сollectionItemTypes)
+    }
+}
+
+fileprivate extension Array {
+    func componentModel(at indexPath: IndexPath) -> ComponentModel? {
+        var subarray = self
+        subarray.removeLast()
+        
+        var index: Int
+        if let _ = subarray as? [CellModel] {
+            index = indexPath.row
+        }
+        else {
+            index = indexPath.section
+        }
+        
+        return self[index] as? ComponentModel
+    }
+}
+
+fileprivate extension UIView {
+    func fillParent() {
+        guard let parent = self.superview else {
+            return
+        }
+        
+        self.translatesAutoresizingMaskIntoConstraints = false
+        self.leadingAnchor.constraint(equalTo: parent.leadingAnchor).isActive = true
+        self.topAnchor.constraint(equalTo: parent.topAnchor).isActive = true
+        self.bottomAnchor.constraint(equalTo: parent.bottomAnchor).isActive = true
+        self.trailingAnchor.constraint(equalTo: parent.trailingAnchor).isActive = true
+    }
+}

--- a/ZeeHomeScreenManifest.json
+++ b/ZeeHomeScreenManifest.json
@@ -10,9 +10,9 @@
     "git@github.com:applicaster-plugins/ZeeHomeScreen-iOS.git"
   ],
   "platform": "ios",
-  "author_name": "Miri Vecselboim",
-  "author_email": "m.vecselboim@applicaster.com",
-  "manifest_version": "2.2.8",
+  "author_name": "S. Borkin",
+  "author_email": "s.borkin@applicaster.com",
+  "manifest_version": "2.2.9",
   "name": "Zee5HomeScreen",
   "description": "Zee5 Home Screen",
   "type": "general",


### PR DESCRIPTION
- The player screen uses home screen content presentation for the related content
- It was using nested scroll views
- Adding the ability to set a static view to the composite screen which the player would put inside the meta data, removing the need to nest scroll views
- Had to wrap SectionCompositeViewController due to access restrictions, didn't want to make the change on SectionCompositeViewController itself