### PR TITLE
zna-7525: Reusing banners without generating extra impressions

### DIFF
--- a/ZeeHomeScreen/Classes/Components/SectionComposite/SectionCompositeViewController.swift
+++ b/ZeeHomeScreen/Classes/Components/SectionComposite/SectionCompositeViewController.swift
@@ -28,6 +28,7 @@ import Zee5CoreSDK
     @IBOutlet weak var topDistanceConstraint:NSLayoutConstraint?
     
     public var atomFeedUrl: String?
+    private var bannerCellReuseIdentifiers: [String] = []
     
     var screenConfiguration: ScreenConfiguration?
     var userType: UserType?
@@ -565,7 +566,10 @@ import Zee5CoreSDK
             
             if let componentModel = sectionsDataSourceArray[index] as? ComponentModel,
                 let layoutName = componentModel.layoutStyle {
-                if let cell = collectionView.dequeueReusableCell(withReuseIdentifier: layoutName, for: indexPath) as? UniversalCollectionViewCell {
+                
+                let reuseIdentifier = (componentModel.type == "BANNER") ? reuseIdentifierForBanner(layoutName: layoutName, index: index) : layoutName
+                
+                if let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as? UniversalCollectionViewCell {
                     componentModel.screenConfiguration = screenConfiguration
                     cell.backgroundColor = UIColor.clear
                     
@@ -585,6 +589,16 @@ import Zee5CoreSDK
         }
         
         return collectionView.dequeueReusableCell(withReuseIdentifier: "ZeeHomeScreen_Family_Ganges_horizontal_list_1", for: indexPath)
+    }
+    
+    // The banner must be loaded once per cell at position
+    private func reuseIdentifierForBanner(layoutName: String, index: Int) -> String {
+        let reuseIdentifier = layoutName + "_at_" + String(index)
+        if (!bannerCellReuseIdentifiers.contains(reuseIdentifier)) {
+            self.collectionView?.register(UniversalCollectionViewCell.self, forCellWithReuseIdentifier: reuseIdentifier)
+            bannerCellReuseIdentifiers.append(reuseIdentifier)
+        }
+        return reuseIdentifier
     }
     
     // MARK: - UICollectionViewDelegate

--- a/ZeeHomeScreen/Classes/Components/SectionComposite/SectionCompositeViewController.swift
+++ b/ZeeHomeScreen/Classes/Components/SectionComposite/SectionCompositeViewController.swift
@@ -138,10 +138,8 @@ import Zee5CoreSDK
         guard let components = component.childerns else {
             return
         }
-        
-        registerLayouts(sectionsArray: components)
-            
-            var newIndexes: [Int] = []
+                    
+        var newIndexes: [Int] = []
             
         collectionView?.performBatchUpdates({
             components.enumerated().forEach { (offset, item) in


### PR DESCRIPTION
The cell is bound to the same view controller no matter how many times it is reused. Using a reuse identifier that is unique for each index would guarantee that the cell will be reused but only when it is loaded for banners with sent impressions.