### PR TITLE
[ZNA-8016] Refactor "Universal" cells to solve memory leak issues

### DIFF
--- a/ZeeHomeScreen/Classes/Components/BasicContainerCell/UniversalCollectionViewCell.h
+++ b/ZeeHomeScreen/Classes/Components/BasicContainerCell/UniversalCollectionViewCell.h
@@ -5,30 +5,15 @@
 //  Created by Miri on 28/01/2020.
 //
 
+@import UIKit;
 
-@import ZappPlugins;
-#import <Foundation/Foundation.h>
-#import "ComponentDelegate.h"
-@class ComponentModel;
-@class ComponentProtocol;
+@protocol ComponentProtocol;
 
-/**
- *  This cell used as container for all components. Do not remove or modify anything without premission
- */
 @interface UniversalCollectionViewCell: UICollectionViewCell
 
-@property (nullable, nonatomic, strong) UIViewController<ComponentProtocol> *componentViewController;
+@property (nonatomic, weak) UIViewController<ComponentProtocol> *componentViewController;
+@property (nonatomic) BOOL parentHandlesReusingComponent;
 
-- (UIViewController<ComponentProtocol> *_Nullable)setComponentModel:(nullable ComponentModel *)componentModel
-               model:(nullable NSObject *)model
-                view:(nullable UIView *)view
-            delegate:(nullable id<ComponentDelegate>)delegate
-                                      parentViewController:(nullable UIViewController *)parentViewController;
-
-
-- (void)setBackgroundImage:(nullable NSString *)imageName;
-
-- (void)addViewControllerToParentViewController:(UIViewController *)parentViewController;
-- (void)removeViewControllerFromParentViewController;
+- (void)setBackgroundImage:(NSString *)imageName;
 
 @end

--- a/ZeeHomeScreen/Classes/Components/BasicContainerCell/UniversalCollectionViewHeaderFooterView.h
+++ b/ZeeHomeScreen/Classes/Components/BasicContainerCell/UniversalCollectionViewHeaderFooterView.h
@@ -5,18 +5,22 @@
 //  Created by Miri on 28/01/2020.
 //
 
-
 @import UIKit;
 
 @protocol ComponentProtocol;
 @protocol UniversalCollectionViewHeaderFooterViewDelegate;
 
 @interface UniversalCollectionViewHeaderFooterView : UICollectionReusableView
-@property (nonatomic, strong) UIViewController <ComponentProtocol> *componentViewController;
-@property (nonatomic, weak)id <UniversalCollectionViewHeaderFooterViewDelegate>delegate;
+
+@property (nonatomic, weak) UIViewController<ComponentProtocol> *componentViewController;
+@property (nonatomic, weak) id<UniversalCollectionViewHeaderFooterViewDelegate> delegate;
+
 -(void)setBackgroundImage:(NSString *) imageName;
+
 @end
 
 @protocol UniversalCollectionViewHeaderFooterViewDelegate <NSObject>
+
 - (void)headerFooterViewDidSelect:(UniversalCollectionViewHeaderFooterView *)headerFooterView;
+
 @end

--- a/ZeeHomeScreen/Classes/Components/BasicContainerCell/UniversalCollectionViewHeaderFooterView.m
+++ b/ZeeHomeScreen/Classes/Components/BasicContainerCell/UniversalCollectionViewHeaderFooterView.m
@@ -5,27 +5,33 @@
 //  Created by Miri on 28/01/2020.
 //
 
-
 #import "UniversalCollectionViewHeaderFooterView.h"
 #import <ZeeHomeScreen/ZeeHomeScreen-Swift.h>
 
 @implementation UniversalCollectionViewHeaderFooterView
 
-
 -(void)prepareForReuse {
     [super prepareForReuse];
+
     _delegate = nil;
-    if ([self.componentViewController respondsToSelector:@selector(prepareComponentForReuse)]) {
-//        [self.componentViewController prepareComponentForReuse];
-    }
+
+    [self.componentViewController removeViewFromParentViewController];
+    _componentViewController = nil;
 }
 
 -(void)setComponentViewController:(UIViewController<ComponentProtocol> *)componentViewController {
+    if (_componentViewController != nil) {
+        [_componentViewController removeViewFromParentViewController];
+    }
+    
     _componentViewController = componentViewController;
+
+    [self addSubview:_componentViewController.view];
+    [_componentViewController.view setInsetsFromParent:UIEdgeInsetsZero];
+    _componentViewController.view.backgroundColor = UIColor.clearColor;
 }
 
--(void)setBackgroundImage:(NSString *) imageName {
-    
+-(void)setBackgroundImage:(NSString *)imageName {
     UIImage *image = [UIImage imageNamed:imageName];
 //    if (self.width > image.size.width) {
 //        //resize image to cell size

--- a/ZeeHomeScreen/Classes/Components/Carousel/CarouselViewController.m
+++ b/ZeeHomeScreen/Classes/Components/Carousel/CarouselViewController.m
@@ -282,20 +282,19 @@ NSString * const kCarouselSwipedNotification = @"CarouselSwipedNotification";
 - (UICollectionViewCell *)promotionView:(APPromotionView *)promotionView cellForItemAtIndexPath:(NSIndexPath *)indexPath {
     
     CellModel *cellModel = self.dataSource[indexPath.row];
-    
-    NSString *reuseIdentifier = [cellModel.identifier stringByAppendingFormat:@"_%@", cellModel.layoutStyle];
-    
+
     UniversalCollectionViewCell *cell = [promotionView dequeueReusableCellWithReuseIdentifier:cellModel.layoutStyle
                                                                                  forIndexPath:indexPath];
     CGFloat width = [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone ? cellModel.iphoneWidth : cellModel.ipadWidth;
     CGFloat height = [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPhone ? cellModel.iphoneHeight : cellModel.ipadHeight;
     cell.frame = CGRectMake(cell.frame.origin.x, cell.frame.origin.y, width, height);
     if (cell.componentViewController == nil) {
-        cell.componentViewController = [ComponenttFactory componentViewControllerWithComponentModel:cellModel
-                                                                                           andModel:cellModel.entry
-                                                                                            forView:cell.contentView
-                                                                                           delegate:self.delegate
-                                                                               parentViewController:self];
+        UIViewController<ComponentProtocol> *componentViewController = [ComponenttFactory viewControllerForComponentModel:cellModel];
+        if (componentViewController != nil) {
+            [self addChildViewController:componentViewController];
+            cell.componentViewController = componentViewController;
+            [componentViewController didMoveToParentViewController:self];
+        }
     }
     
     if ([cell.componentViewController respondsToSelector:@selector(delegate)]) {

--- a/ZeeHomeScreen/Classes/Components/Cell/CellViewController.swift
+++ b/ZeeHomeScreen/Classes/Components/Cell/CellViewController.swift
@@ -12,7 +12,7 @@ import ApplicasterSDK
     
     public var selectedModel: NSObject?
     
-    public var delegate: ComponentDelegate?
+    public weak var delegate: ComponentDelegate?
     
     
     //MARK: Properties

--- a/ZeeHomeScreen/Classes/Components/SectionComposite/SectionCompositeViewController.swift
+++ b/ZeeHomeScreen/Classes/Components/SectionComposite/SectionCompositeViewController.swift
@@ -567,13 +567,28 @@ import Zee5CoreSDK
                 if let cell = collectionView.dequeueReusableCell(withReuseIdentifier: reuseIdentifier, for: indexPath) as? UniversalCollectionViewCell {
                     componentModel.screenConfiguration = screenConfiguration
                     cell.backgroundColor = UIColor.clear
-                    
-                    let _ = cell.setComponentModel(componentModel,
-                    model: componentModel,
-                    view: cell.contentView,
-                    delegate: self,
-                    parentViewController: self)
 
+                    if (cell.componentViewController == nil) {
+                        if let componentViewController = ComponenttFactory.viewController(for: componentModel) {
+                            addChild(componentViewController)
+                            cell.componentViewController = componentViewController
+                            componentViewController.didMove(toParent: self)
+                        }
+                    } else {
+                        if cell.componentViewController?.responds(to: #selector(setter: ComponentProtocol.componentModel)) == true {
+                            _ = cell.componentViewController?.perform(#selector(setter: ComponentProtocol.componentModel), with: componentModel)
+                        }
+                        if cell.componentViewController?.responds(to: #selector(ComponentProtocol.rebuildComponent)) == true {
+                            _ = cell.componentViewController?.perform(#selector(ComponentProtocol.rebuildComponent))
+                        }
+                    }
+
+                    if cell.componentViewController?.responds(to: #selector(setter: ComponentProtocol.delegate)) == true {
+                        _ = cell.componentViewController?.perform(#selector(setter: ComponentProtocol.delegate), with: delegate)
+                    }
+                    if cell.componentViewController?.responds(to: #selector(setter: ComponentProtocol.componentDataSourceModel)) == true {
+                        _ = cell.componentViewController?.perform(#selector(setter: ComponentProtocol.componentDataSourceModel), with: componentModel)
+                    }
 
                     cell.layer.shouldRasterize = true
                     cell.layer.rasterizationScale = UIScreen.main.scale
@@ -648,25 +663,27 @@ import Zee5CoreSDK
             let header =  componentModel.componentHeaderModel,
             let layoutName =  header.layoutStyle {
             if let headerView = collectionView.dequeueReusableSupplementaryView(ofKind: kind, withReuseIdentifier: layoutName, for: indexPath) as? UniversalCollectionViewHeaderFooterView {
-                
                 headerView.delegate = self
-                /*if headerView.componentViewController == nil,*/
-                    if let currentModel = header.entry as? APModel {
-                    headerView.componentViewController =  ComponenttFactory.componentViewController(with: header,
-                                                              andModel: currentModel,
-                                                              for: headerView,
-                                                              delegate: self,
-                                                              parentViewController: self)
+
+                if let _ = header.entry as? APModel {
+                    if let componentViewController = ComponenttFactory.viewController(for: header) {
+                        addChild(componentViewController)
+                        headerView.componentViewController = componentViewController
+                        componentViewController.didMove(toParent: self)
+                    }
+
                     if headerView.componentViewController?.responds(to: #selector(setter: ComponentProtocol.delegate)) == true {
                         _ = headerView.componentViewController?.perform(#selector(setter: ComponentProtocol.delegate), with: self)
                     }
                 }
+
                 if headerView.componentViewController?.responds(to: #selector(setter: ComponentProtocol.componentModel)) == true {
                     _ = headerView.componentViewController?.perform(#selector( setter: ComponentProtocol.componentModel), with: header)
                 }
                 if headerView.componentViewController?.responds(to: #selector(setter: ComponentProtocol.componentDataSourceModel)) == true {
-                    _ = headerView.componentViewController?.perform(#selector( setter: ComponentProtocol.componentDataSourceModel), with: header)
+                    _ = headerView.componentViewController?.perform(#selector(setter: ComponentProtocol.componentDataSourceModel), with: header)
                 }
+
                 reusableview = headerView
             }
         }

--- a/ZeeHomeScreen/Classes/Factory/ComponenttFactory.h
+++ b/ZeeHomeScreen/Classes/Factory/ComponenttFactory.h
@@ -5,26 +5,14 @@
 //  Created by Miri on 11.12.19.
 //
 
-#import "ComponenttFactory.h"
-
-@class APModel;
 @class ComponentModel;
 
-@class ComponentViewController;
 @protocol ComponentProtocol;
-@protocol ComponentDelegate;
 
 @interface ComponenttFactory : NSObject
 
 #pragma mark - Public Methods
 
-+ (UIViewController <ComponentProtocol>  *)componentViewControllerWithComponentModel:(ComponentModel *)componentModel
-                                                                              andModel:(NSObject *)model
-                                                                               forView:(UIView *)view
-                                                                              delegate:(id <ComponentDelegate>) delegate
-                                                                  parentViewController:(UIViewController *)parentViewController;
-
-+ (UIViewController <ComponentProtocol> *)viewControllerForComponentModel:(ComponentModel *)componentModel
-                                                                withModel:(APModel *)model;
++ (UIViewController <ComponentProtocol> *)viewControllerForComponentModel:(ComponentModel *)componentModel;
 
 @end

--- a/ZeeHomeScreen/Classes/Factory/ComponenttFactory.m
+++ b/ZeeHomeScreen/Classes/Factory/ComponenttFactory.m
@@ -22,52 +22,6 @@
 
 #pragma mark - Definitions
 
-+ (UIViewController <ComponentProtocol>  *)componentViewControllerWithComponentModel:(ComponentModel *)componentModel
-                                                                              andModel:(NSObject *)model
-                                                                               forView:(UIView *)view
-                                                                              delegate:(id <ComponentDelegate>) delegate
-                                                                  parentViewController:(UIViewController *)parentViewController {
-    
-    UIViewController <ComponentProtocol>  *retVal = [self viewControllerForComponentModel:componentModel
-                                                                                  withModel:(APModel *)model];
-    if (retVal != nil) {
-        
-        // If the view (container) is not pass or nil use the parent view.
-        if (view == nil) {
-            view = parentViewController.view;
-        }
-        
-        if (view) {
-            if (delegate) {
-                if ([retVal respondsToSelector:@selector(delegate)]) {
-                    retVal.delegate = delegate;
-                }
-            }
-            
-            UIEdgeInsets paddingInsets = UIEdgeInsetsMake(0.0, 0.0, 0.0, 0.0);
-//            [CAUIBuilderRealScreenSizeHelper componentPaddingWithComponentModel:componentModel     model:model];
-            [view removeAllSubviews];
-            [view addSubview:retVal.view];
-            
-            [retVal.view matchParent];
-            [retVal.view setInsetsFromParent:paddingInsets];
-        }
-        
-        if (parentViewController) {
-            [parentViewController addChildViewController:retVal];
-            [retVal didMoveToParentViewController:parentViewController];
-        }
-        
-        retVal.view.backgroundColor = [UIColor clearColor];
-    }
-    else {
-        APLoggerError(@"Can't create component - %@", componentModel);
-    }
-    
-    
-    return retVal;
-}
-
 + (NSString *)viewControllerClassNameforType:(NSString *)type {
     NSString *retVal;
     if ([type isEqualToString:@"HERO"]) {
@@ -152,8 +106,7 @@
     return viewController;
 }
 
-+ (UIViewController <ComponentProtocol> *)viewControllerForComponentModel:(ComponentModel *)componentModel
-                                                                  withModel:(APModel *)model {
++ (UIViewController <ComponentProtocol> *)viewControllerForComponentModel:(ComponentModel *)componentModel {
     UIViewController <ComponentProtocol> *viewController = nil;
     NSString *xibKeyName = componentModel.layoutStyle;
     
@@ -178,6 +131,11 @@
             }
         }
     }
+
+    if (viewController == nil) {
+        APLoggerError(@"Can't create component - %@", componentModel);
+    }
+
     return viewController;
 }
 


### PR DESCRIPTION
Current way of handling children View Controllers in "Universal" cells
leaves strong references to reused View Controllers in childViewControllers.
Refactor the whole "Universal" cell View Controller hosting mechanism to
resolve memory leak problems and improve performance of the home screen.

Initial testing has shown reduction of memory usage starting from 50 MB per
single home tab, multiplied by number of open tabs.