### PR TITLE
[ZNA-8014] Lazy load EPG view on SectionCompositeViewController

### DIFF
--- a/ZeeHomeScreen/Classes/Components/SectionComposite/SectionCompositeViewController.swift
+++ b/ZeeHomeScreen/Classes/Components/SectionComposite/SectionCompositeViewController.swift
@@ -274,27 +274,43 @@ import Zee5CoreSDK
         }
         toggle.setButtonsTitles(buttonsTitles: ["nav_livetv".localized(hashMap: [:]), "EPG_Header_ChannelGuide_Text".localized(hashMap: [:])])
         toggle.changeToIndex = { [weak self] index in
-            self?.collectionView?.isHidden = index == 0 ? false : true
-            self?.epgContentView?.isHidden = index == 0 ? true : false
+            switch index {
+            case 0:
+                self?.collectionView?.isHidden = false
+                self?.epgContentView?.isHidden = true
+
+            case 1:
+                self?.prepareEPGViewIfNeeded()
+                self?.collectionView?.isHidden = true
+                self?.epgContentView?.isHidden = false
+
+            default: ()
+            }
         }
         toggle.isHidden = false
     }
     
-    private func prepareEPGView() {
+    private func prepareEPGViewIfNeeded() {
+        guard epgContentView?.subviews.isEmpty == true else { return }
 
         let screenID = screenConfiguration?.epgScreenID
 
-        guard let viewController = GARootHelper.uiBuilderScreen(by: screenID!,
-                                                                model: nil,
-                                                                fromURLScheme:nil) else {
-                                                                    APLoggerError("Can not create view controller with ScreenType: \(screenID!) isn't found")
-                                                                    return
+        guard let viewController = GARootHelper.uiBuilderScreen(
+            by: screenID!,
+            model: nil,
+            fromURLScheme: nil
+        ) as? GAScreenPluginGenericViewController else {
+            APLoggerError("Can not create view controller with ScreenType: \(screenID!) isn't found")
+            return
         }
-        (viewController as! GAScreenPluginGenericViewController).isContainerViewController = true
+
+        viewController.isContainerViewController = true
         addChild(viewController)
 
-        epgContentView!.addSubview(viewController.view)
+        epgContentView?.addSubview(viewController.view)
         viewController.view.matchParent()
+
+        viewController.didMove(toParent: self)
     }
     
     func prepareComponentToReuse() {
@@ -341,7 +357,6 @@ import Zee5CoreSDK
                 if config.epgScreenID != nil {
                     topDistanceConstraint?.constant = -64
                     prepareToggle()
-                    prepareEPGView()
                 }
             }
             

--- a/ZeeHomeScreen/Classes/Models/ComponentModel.swift
+++ b/ZeeHomeScreen/Classes/Models/ComponentModel.swift
@@ -39,7 +39,7 @@ import ApplicasterSDK
     @objc open var containerType: String?
     //, ComponentModelProtocol {
     
-    open var parentModel: ComponentModel?
+    open weak var parentModel: ComponentModel?
     open var title: String?
     
     open var identifier: String?

--- a/ZeeHomeScreen/Classes/ZeeHomeScreenMain.swift
+++ b/ZeeHomeScreen/Classes/ZeeHomeScreenMain.swift
@@ -17,7 +17,7 @@ public class ZeeHomeScreenMain: NSObject, ZPPluggableScreenProtocol {
     
     public var configurationJSON: NSDictionary?
     
-    public var screenPluginDelegate: ZPPlugableScreenDelegate?
+    public weak var screenPluginDelegate: ZPPlugableScreenDelegate?
     var mainViewController: SectionCompositeViewController?
     
     fileprivate var config: PluginKeys?


### PR DESCRIPTION
Currently, opening SectionCompositeViewControllers with EPG enabled will cause
the whole React Native runtime to load, even if user never taps the EPG button.
Those changes modify this behavior to load EPG not when the screen is created
but rather when user opens the EPG view. It saves a lot of memory when swiping
through the home screen, because React Native is loaded only when it's used.